### PR TITLE
add alias and make miscellaneous changes

### DIFF
--- a/R/stringi-package.R
+++ b/R/stringi-package.R
@@ -34,7 +34,7 @@
 #' @description
 #' \pkg{stringi} is THE \R package for fast, correct, consistent,
 #' and convenient string/text manipulation.
-#' We put a lot of effort to create a software package that
+#' We put a lot of effort into creating a software package that
 #' gives predictable results on every platform, in each locale,
 #' and under any ``native'' character encoding.
 #'
@@ -48,9 +48,8 @@
 #' and the UCD license for the Unicode Character Database.
 #' See the COPYRIGHTS and LICENSE file for more details.
 #'
-#'
 #' @details
-#' Manual pages on general topics (must-read):
+#' Manual pages on general topics:
 #' \itemize{
 #' \item \link{stringi-encoding} -- character encoding issues, including
 #'    information on encoding management in \pkg{stringi}, as well as
@@ -149,6 +148,7 @@
 #'
 #' @name stringi-package
 #' @rdname stringi-package
+#' @aliases stringi
 #' @docType package
 #' @author Marek Gagolewski \email{gagolews@@rexamine.com},\cr
 #' Bartek Tartanus \email{bartektartanus@@rexamine.com},\cr

--- a/R/trim.R
+++ b/R/trim.R
@@ -61,9 +61,9 @@
 #' see \link{stringi-search-charclass}.
 #'
 #' @param str a character vector of strings to be trimmed
-#' @param pattern a single regular expression, formatted as a string, specifying character classes that
-#' should be preserved, see \link{stringi-search-charclass},
-#' defaults to `\code{\\P\{Wspace\}}`
+#' @param pattern a single ICU regular expression, formatted as a string, specifying character
+#' classes that should be preserved (see \link{stringi-search-charclass}). Defaults to
+#' `\code{\\P\{Wspace\}}.
 #' @param side character [\code{stri_trim} only]; defaults to \code{"both"}
 #'
 #' @return All these functions return a character vector.

--- a/R/trim.R
+++ b/R/trim.R
@@ -40,9 +40,9 @@
 #' @details
 #' Vectorized over \code{str} and \code{pattern}.
 #'
-#' \code{stri_trim} is a convenience function, which dispatches
-#' control to \code{stri_trim_*}. Unless you are very lazy, do not use it:
-#' it is a little bit slower.
+#' \code{stri_trim} is a wrapper, which calls \code{stri_trim_left}
+#' or \code{stri_trim_right} as appropriate. It's slightly slower than trim_left or
+#' trim_right, and so shouldn't be used except for convenience.
 #'
 #' Contrary to many other string processing libraries,
 #' our trimming functions are quite general. A character class,
@@ -60,8 +60,8 @@
 #' and general character category `\code{\\p\{Z\}}`,
 #' see \link{stringi-search-charclass}.
 #'
-#' @param str character vector
-#' @param pattern character vector specifying character classes that
+#' @param str a character vector of strings to be trimmed
+#' @param pattern a single regular expression, formatted as a string, specifying character classes that
 #' should be preserved, see \link{stringi-search-charclass},
 #' defaults to `\code{\\P\{Wspace\}}`
 #' @param side character [\code{stri_trim} only]; defaults to \code{"both"}

--- a/R/trim.R
+++ b/R/trim.R
@@ -61,7 +61,7 @@
 #' see \link{stringi-search-charclass}.
 #'
 #' @param str a character vector of strings to be trimmed
-#' @param pattern a single ICU regular expression, formatted as a string, specifying character
+#' @param pattern a single pattern, specifying character
 #' classes that should be preserved (see \link{stringi-search-charclass}). Defaults to
 #' `\code{\\P\{Wspace\}}.
 #' @param side character [\code{stri_trim} only]; defaults to \code{"both"}

--- a/man/stri_trim.Rd
+++ b/man/stri_trim.Rd
@@ -18,7 +18,7 @@ stri_trim(str, side = c("both", "left", "right"), pattern = "\\\\P{Wspace}")
 \arguments{
 \item{str}{a character vector of strings to be trimmed}
 
-\item{pattern}{a single ICU regular expression, formatted as a string, specifying character
+\item{pattern}{a single pattern, specifying character
 classes that should be preserved (see \link{stringi-search-charclass}). Defaults to
 `\code{\\P\{Wspace\}}.}
 

--- a/man/stri_trim.Rd
+++ b/man/stri_trim.Rd
@@ -16,9 +16,9 @@ stri_trim_right(str, pattern = "\\\\P{Wspace}")
 stri_trim(str, side = c("both", "left", "right"), pattern = "\\\\P{Wspace}")
 }
 \arguments{
-\item{str}{character vector}
+\item{str}{a character vector of strings to be trimmed}
 
-\item{pattern}{character vector specifying character classes that
+\item{pattern}{a single regular expression, formatted as a string, specifying character classes that
 should be preserved, see \link{stringi-search-charclass},
 defaults to `\code{\\P\{Wspace\}}`}
 
@@ -35,9 +35,9 @@ starts at the last \code{pattern} match.
 \details{
 Vectorized over \code{str} and \code{pattern}.
 
-\code{stri_trim} is a convenience function, which dispatches
-control to \code{stri_trim_*}. Unless you are very lazy, do not use it:
-it is a little bit slower.
+\code{stri_trim} is a wrapper, which calls \code{stri_trim_left}
+or \code{stri_trim_right} as appropriate. It's slightly slower than trim_left or
+trim_right, and so shouldn't be used except for convenience.
 
 Contrary to many other string processing libraries,
 our trimming functions are quite general. A character class,

--- a/man/stri_trim.Rd
+++ b/man/stri_trim.Rd
@@ -18,9 +18,9 @@ stri_trim(str, side = c("both", "left", "right"), pattern = "\\\\P{Wspace}")
 \arguments{
 \item{str}{a character vector of strings to be trimmed}
 
-\item{pattern}{a single regular expression, formatted as a string, specifying character classes that
-should be preserved, see \link{stringi-search-charclass},
-defaults to `\code{\\P\{Wspace\}}`}
+\item{pattern}{a single ICU regular expression, formatted as a string, specifying character
+classes that should be preserved (see \link{stringi-search-charclass}). Defaults to
+`\code{\\P\{Wspace\}}.}
 
 \item{side}{character [\code{stri_trim} only]; defaults to \code{"both"}}
 }

--- a/man/stringi-arguments.Rd
+++ b/man/stringi-arguments.Rd
@@ -71,12 +71,12 @@ or use e.g. the subsetting operation like \code{x[] <- stri_...(x, ...)}.
 \seealso{
 Other stringi_general_topics: \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-encoding.Rd
+++ b/man/stringi-encoding.Rd
@@ -233,12 +233,12 @@ Other encoding_management: \code{\link{stri_enc_get}},
 
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-locale.Rd
+++ b/man/stringi-locale.Rd
@@ -148,12 +148,12 @@ Other locale_sensitive: \code{\link{\%s!==\%}},
 
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-package.Rd
+++ b/man/stringi-package.Rd
@@ -2,12 +2,13 @@
 % Please edit documentation in R/stringi-package.R
 \docType{package}
 \name{stringi-package}
+\alias{stringi}
 \alias{stringi-package}
 \title{THE String Processing Package}
 \description{
 \pkg{stringi} is THE \R package for fast, correct, consistent,
 and convenient string/text manipulation.
-We put a lot of effort to create a software package that
+We put a lot of effort into creating a software package that
 gives predictable results on every platform, in each locale,
 and under any ``native'' character encoding.
 
@@ -22,7 +23,7 @@ and the UCD license for the Unicode Character Database.
 See the COPYRIGHTS and LICENSE file for more details.
 }
 \details{
-Manual pages on general topics (must-read):
+Manual pages on general topics:
 \itemize{
 \item \link{stringi-encoding} -- character encoding issues, including
    information on encoding management in \pkg{stringi}, as well as

--- a/man/stringi-search-boundaries.Rd
+++ b/man/stringi-search-boundaries.Rd
@@ -99,12 +99,12 @@ Other locale_sensitive: \code{\link{\%s!==\%}},
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 
 Other text_boundaries: \code{\link{stri_count_boundaries}},
   \code{\link{stri_count_words}};

--- a/man/stringi-search-charclass.Rd
+++ b/man/stringi-search-charclass.Rd
@@ -283,11 +283,11 @@ Other search_charclass: \code{\link{stri_trim}},
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-search-coll.Rd
+++ b/man/stringi-search-coll.Rd
@@ -88,11 +88,11 @@ Other search_coll: \code{\link{stri_opts_collator}};
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-fixed}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-search-fixed.Rd
+++ b/man/stringi-search-fixed.Rd
@@ -37,11 +37,11 @@ Other search_fixed: \code{\link{stri_opts_fixed}};
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-regex}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-search-regex.Rd
+++ b/man/stringi-search-regex.Rd
@@ -203,11 +203,11 @@ Other search_regex: \code{\link{stri_opts_regex}};
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
-  \code{\link{stringi-search}}
+  \code{\link{stringi-search}}; \code{\link{stringi}},
+  \code{\link{stringi-package}}
 }
 

--- a/man/stringi-search.Rd
+++ b/man/stringi-search.Rd
@@ -180,12 +180,12 @@ Other search_subset: \code{\link{stri_subset}},
 Other stringi_general_topics: \code{\link{stringi-arguments}};
   \code{\link{stringi-encoding}};
   \code{\link{stringi-locale}};
-  \code{\link{stringi-package}};
   \code{\link{stringi-search-boundaries}};
   \code{\link{stringi-search-charclass}};
   \code{\link{stringi-search-coll}};
   \code{\link{stringi-search-fixed}};
-  \code{\link{stringi-search-regex}}
+  \code{\link{stringi-search-regex}};
+  \code{\link{stringi}}, \code{\link{stringi-package}}
 
 Other text_boundaries: \code{\link{stri_count_boundaries}},
   \code{\link{stri_count_words}};


### PR DESCRIPTION
This patch makes miscellaneous documentation tweaks, specifically:

1. Correcting typos in the main stringi-package documentation;
2. Removing a "must read" (unless it's impossible to understand any functionality without reading all of the documentation, it's not a must-read);
3. Adding stringi as a roxygen2 alias so that the main page and associated index can be conveniently loaded via ?stringi
4. Correcting the documentation around stri_trim so that it's simpler, makes clear that "pattern" can only be a length-one vector, and doesn't insult the user (stri_trim should be called for convenience, sure. using it does not make the user "lazy")