### PR TITLE
Update Makevars.win

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -39,10 +39,10 @@ $(SHLIB): $(OBJECTS) libicu_common.a libicu_i18n.a libicu_stubdata.a
 PKG_LIBS=-L. -licu_common -licu_i18n -licu_stubdata
 
 libicu_common.a: $(ICU_COMMON_OBJECTS)
-	ar rcs -o libicu_common.a $(ICU_COMMON_OBJECTS)
+	$(AR) rcs -o libicu_common.a $(ICU_COMMON_OBJECTS)
 
 libicu_i18n.a: $(ICU_I18N_OBJECTS)
-	ar rcs -o libicu_i18n.a $(ICU_I18N_OBJECTS)
+	$(AR) rcs -o libicu_i18n.a $(ICU_I18N_OBJECTS)
 
 libicu_stubdata.a: $(ICU_STUBDATA_OBJECTS)
-	ar rcs -o libicu_stubdata.a $(ICU_STUBDATA_OBJECTS)
+	$(AR) rcs -o libicu_stubdata.a $(ICU_STUBDATA_OBJECTS)


### PR DESCRIPTION
By changing hard-coded `ar` to its R variable, stringi can inherit any prefixes which may be added to R when compiled from source. This will be useful for the experimental 4.9.2 toolchain, which when link-time optimization (LTO) is being used, needs to call `ar`, `nm`, and `ranlib` as `gcc-ar`, `gcc-nm`, and `gcc-ranlib`. Changes to Mkrules and Makeconf in R are being investigated. Under the current toolset, or without LTO, $(AR) will just be `ar`.